### PR TITLE
Add a PushModalPlainAsync() method

### DIFF
--- a/VMFirstNav/NavigationService.cs
+++ b/VMFirstNav/NavigationService.cs
@@ -201,6 +201,13 @@ namespace CodeMill.VMFirstNav
 			await FormsNavigation.PushModalAsync(nv);
 		}
 
+        public async Task PushModalPlainAsync<T>(T viewModel) where T : class, IViewModel
+        {
+            var view = InstantiateView(viewModel);
+
+            await FormsNavigation.PushModalAsync((Page)view);
+        }
+
 		public async Task PushAsync<T>(Action<T> initialize = null) where T : class, IViewModel
 		{
 			T viewModel;


### PR DESCRIPTION
I noticed that the existing `PushModalAsync()` method wraps everything in a `NavigationPage` which may not be desired behavior in some cases. So I added this method to the `NavigationService.cs` file to allow developers to push a modal as-is. This is just a super-quick fix and there is probably a better way to implement this kind of flexibility.